### PR TITLE
Minimally scope permissions in GitHub Actions workflows

### DIFF
--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -6,19 +6,19 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
+
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   setup:
     name: Setup
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
+    permissions: {}
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
     steps:
@@ -31,25 +31,27 @@ jobs:
   bluehost:
     name: Bluehost Build and Test Playwright
     needs: setup
-    permissions:
-      contents: read
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
+    permissions:
+      actions: write      # Required for reusable Playwright workflow cache save/restore and artifact uploads.
+      contents: read      # Required for delegated checkouts against private Composer and git dependencies.
+    secrets: inherit
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
       plugin-repo: 'newfold-labs/wp-plugin-bluehost'
-    secrets: inherit
 
   bluehost-dev:
     name: Bluehost Dev Build and Test Playwright
     needs: setup
-    permissions:
-      contents: read
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
+    permissions:
+      actions: write      # Required for reusable Playwright workflow cache save/restore and artifact uploads.
+      contents: read      # Required for delegated checkouts against private Composer and git dependencies.
+    secrets: inherit
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
       plugin-repo: 'newfold-labs/wp-plugin-bluehost'
       plugin-branch: 'develop'
       artifact-name: 'wp-plugin-bluehost-develop'
-    secrets: inherit

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -34,10 +34,11 @@ jobs:
   bluehost:
     name: Bluehost Build and Test Playwright
     needs: setup
-    uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
       actions: write      # Required for reusable Playwright workflow cache save/restore and artifact uploads.
       contents: read      # Required for delegated checkouts against private Composer and git dependencies.
+
+    uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
 
     timeout-minutes: 60
 
@@ -50,10 +51,11 @@ jobs:
   bluehost-dev:
     name: Bluehost Dev Build and Test Playwright
     needs: setup
-    uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
       actions: write      # Required for reusable Playwright workflow cache save/restore and artifact uploads.
       contents: read      # Required for delegated checkouts against private Composer and git dependencies.
+
+    uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
 
     timeout-minutes: 60
 

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -19,6 +19,9 @@ jobs:
     name: Setup
     runs-on: ubuntu-latest
     permissions: {}
+
+    timeout-minutes: 10
+
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
     steps:
@@ -35,6 +38,9 @@ jobs:
     permissions:
       actions: write      # Required for reusable Playwright workflow cache save/restore and artifact uploads.
       contents: read      # Required for delegated checkouts against private Composer and git dependencies.
+
+    timeout-minutes: 60
+
     secrets: inherit
     with:
       module-repo: ${{ github.repository }}
@@ -48,6 +54,9 @@ jobs:
     permissions:
       actions: write      # Required for reusable Playwright workflow cache save/restore and artifact uploads.
       contents: read      # Required for delegated checkouts against private Composer and git dependencies.
+
+    timeout-minutes: 60
+
     secrets: inherit
     with:
       module-repo: ${{ github.repository }}

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -13,12 +13,14 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   get-repo-name:
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}
     steps:
@@ -30,10 +32,11 @@ jobs:
 
   codecoverage:
     needs: get-repo-name
-    permissions:
-      contents: write
-      pull-requests: write
     uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
+    permissions:
+      actions: write       # Required for Actions cache reads/writes executed inside the reusable workflow jobs.
+      contents: write      # Required for the reusable codecoverage workflow to push coverage HTML to gh-pages.
+      pull-requests: write # Required for the reusable codecoverage workflow to comment on pull requests.
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
       coverage-php-version: '7.4'

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -35,11 +35,12 @@ jobs:
 
   codecoverage:
     needs: get-repo-name
-    uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
     permissions:
       actions: write       # Required for Actions cache reads/writes executed inside the reusable workflow jobs.
       contents: write      # Required for the reusable codecoverage workflow to push coverage HTML to gh-pages.
       pull-requests: write # Required for the reusable codecoverage workflow to comment on pull requests.
+
+    uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
 
     timeout-minutes: 60
 

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -21,6 +21,9 @@ jobs:
   get-repo-name:
     runs-on: ubuntu-latest
     permissions: {}
+
+    timeout-minutes: 10
+
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}
     steps:
@@ -37,6 +40,9 @@ jobs:
       actions: write       # Required for Actions cache reads/writes executed inside the reusable workflow jobs.
       contents: write      # Required for the reusable codecoverage workflow to push coverage HTML to gh-pages.
       pull-requests: write # Required for the reusable codecoverage workflow to comment on pull requests.
+
+    timeout-minutes: 60
+
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
       coverage-php-version: '7.4'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,6 +28,8 @@ jobs:
       pull-requests: read  # Required for technote-space/get-diff-action GitHub API access on pull_request events.
       actions: write      # Required so actions/cache can restore and save Composer cache entries.
 
+    timeout-minutes: 30
+
     steps:
 
       - name: Checkout

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,10 +15,19 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   phpcs:
     name: Run PHP Code Sniffer
     runs-on: ubuntu-latest
+    permissions:
+      contents: read       # Required to clone the repo when using actions/checkout.
+      pull-requests: read  # Required for technote-space/get-diff-action GitHub API access on pull_request events.
+      actions: write      # Required so actions/cache can restore and save Composer cache entries.
+
     steps:
 
       - name: Checkout

--- a/.github/workflows/newfold-prep-release.yml
+++ b/.github/workflows/newfold-prep-release.yml
@@ -26,6 +26,9 @@ jobs:
       actions: write      # Required so setup-node/npm caching invoked in the delegated workflow can use Actions cache.
       contents: write     # Required for actions/checkout persist-credentials and delegated commits/branches pushes.
       pull-requests: write # Required for delegated gh/API steps that create PRs plus read merged PR metadata.
+
+    timeout-minutes: 45
+
     with:
       module-repo: ${{ github.repository }}
       module-branch: 'main'

--- a/.github/workflows/newfold-prep-release.yml
+++ b/.github/workflows/newfold-prep-release.yml
@@ -21,10 +21,11 @@ jobs:
   # This job runs the newfold module-prep-release workflow for this module.
   prep-release:
     name: Prepare Release
-    permissions:
-      contents: write
-      pull-requests: write
     uses: newfold-labs/workflows/.github/workflows/reusable-module-prep-release.yml@main
+    permissions:
+      actions: write      # Required so setup-node/npm caching invoked in the delegated workflow can use Actions cache.
+      contents: write     # Required for actions/checkout persist-credentials and delegated commits/branches pushes.
+      pull-requests: write # Required for delegated gh/API steps that create PRs plus read merged PR metadata.
     with:
       module-repo: ${{ github.repository }}
       module-branch: 'main'

--- a/.github/workflows/newfold-prep-release.yml
+++ b/.github/workflows/newfold-prep-release.yml
@@ -21,11 +21,12 @@ jobs:
   # This job runs the newfold module-prep-release workflow for this module.
   prep-release:
     name: Prepare Release
-    uses: newfold-labs/workflows/.github/workflows/reusable-module-prep-release.yml@main
     permissions:
       actions: write      # Required so setup-node/npm caching invoked in the delegated workflow can use Actions cache.
       contents: write     # Required for actions/checkout persist-credentials and delegated commits/branches pushes.
       pull-requests: write # Required for delegated gh/API steps that create PRs plus read merged PR metadata.
+
+    uses: newfold-labs/workflows/.github/workflows/reusable-module-prep-release.yml@main
 
     timeout-minutes: 45
 

--- a/.github/workflows/satis-webhook.yml
+++ b/.github/workflows/satis-webhook.yml
@@ -16,6 +16,8 @@ jobs:
     permissions:
       contents: read # Required to clone the repo when using actions/checkout.
 
+    timeout-minutes: 30
+
     steps:
 
       - name: Checkout

--- a/.github/workflows/satis-webhook.yml
+++ b/.github/workflows/satis-webhook.yml
@@ -5,10 +5,17 @@ on:
     types:
       - created
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   webhook:
     name: Send Webhook
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required to clone the repo when using actions/checkout.
+
     steps:
 
       - name: Checkout


### PR DESCRIPTION
This updates the GitHub Actions workflow files to:

- Grant minimally-scoped permissions to each job to adhere to the principle of least privilege
- Specify a timeout on each job to prevent runaway processes consuming too many minutes (the default is 360)

Once this PR is merged, [the Settings -> Actions -> Workflow permissions setting](https://github.com/newfold-labs/wp-module-context/settings/actions) can be changed by a repo admin to "Read repository contents and packages permissions".

For more information, see [PRESS11-470](https://newfold.atlassian.net/browse/PRESS11-470).

## References

- https://docs.github.com/en/actions/reference/security/secure-use
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes

## Use of AI

Cursor was used with (Claude Opus 4.7 and Composer 2.0 at varying points) to analyze the repository and make the initial changes.

When this PR is marked "ready for review" it means that I have manually reviewed all permissions and timeouts that were changed and made any necessary adjustments.

As a part of the analysis, the following summary was created:

## Status

| Field | Value |
|---|---|
| Workflows scanned | 5 (`brand-plugin-test-playwright.yml`, `codecoverage-main.yml`, `lint.yml`, `newfold-prep-release.yml`, `satis-webhook.yml`) |
| Branch | `add/scoped-workflow-permissions` (created) |
| Permissions commit | `2d6502d` |
| Timeouts commit | `3a912ae` |


## Top-level `permissions: {}`

| Category | Entry |
|---|---|
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `brand-plugin-test-playwright.yml` (top-level `permissions: read` was replaced with the standard commented empty block immediately before `jobs:`) |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `codecoverage-main.yml` (top-level `contents: read` was replaced with the standard commented empty block immediately before `jobs:`) |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `lint.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `satis-webhook.yml` |


## Job-level `permissions:` additions

| Workflow file | Summary | Job | Permissions / notes |
|---|---|---|---|
| satis-webhook.yml | 1 job was missing a scoped `permissions:` directive | webhook | `contents: read` [3] |
| lint.yml | 1 job was missing a scoped `permissions:` directive | phpcs | `contents: read`, `pull-requests: read`, `actions: write` [2] |
| codecoverage-main.yml | 1 job was missing a scoped `permissions:` directive | get-repo-name | `permissions: {}` [3] |
| brand-plugin-test-playwright.yml | 0 jobs needed a brand-new `permissions:` key (the `setup` job already declared `permissions:` before this run; it was tightened in the corrections section rather than added from scratch) | — | — |
| newfold-prep-release.yml | 0 jobs needed a brand-new `permissions:` key (`prep-release` already declared `permissions:` before this run; it was tightened/reordered in the corrections section) | — | — |


## Permissions corrections (previously incorrect)

| # | Correction |
|---:|---|
| 1 | `brand-plugin-test-playwright.yml` :: `setup`: BEFORE `contents: read` -> AFTER `permissions: {}` -- setup only emits the branch name from job context and does not run `actions/checkout`, so the default `GITHUB_TOKEN` is not needed for repository access here -- [3] |
| 2 | `brand-plugin-test-playwright.yml` :: `bluehost`: BEFORE `contents: read` -> AFTER `contents: read`, `actions: write` (with inline justification comments) -- delegated `module-plugin-test-playwright.yml` uses `actions/cache` and `actions/upload-artifact`, which require Actions cache/artifact APIs in addition to cloning private dependencies -- [2] |
| 3 | `brand-plugin-test-playwright.yml` :: `bluehost-dev`: BEFORE `contents: read` -> AFTER `contents: read`, `actions: write` (with inline justification comments) -- same rationale as `bluehost` because it calls the identical reusable workflow with only different inputs/branches -- [2] |
| 4 | `codecoverage-main.yml` :: `codecoverage`: BEFORE `contents: write` and `pull-requests: write` (no Actions-scoped allowance, `permissions` preceding `uses`) -> AFTER `uses`-first layout with `actions: write`, `contents: write`, and `pull-requests: write` (each with inline justification comments) -- reusable `reusable-codecoverage.yml` restores/saves workflow caches (`actions/cache`-backed tooling) while pushing gh-pages commits and manipulating PR discussions/comments -- [2] |
| 5 | `newfold-prep-release.yml` :: `prep-release`: BEFORE `permissions` placed before `uses`, `contents: write`, `pull-requests: write`, no `actions: write` allowance -> AFTER `uses` preceding `permissions` with `contents: write`, `pull-requests: write`, `actions: write` (each with inline justification comments) -- reusable `reusable-module-prep-release.yml` runs `npm`/`setup-node` caching plus `git`/`gh`-driven branching/PR workflows, so granting Actions-cache scope aligns with delegated steps -- [2] |


## `timeout-minutes` additions

| Workflow | Job | Minutes / action | Rationale |
|---|---|---|---|
| satis-webhook.yml | webhook | `30` | simple checkout plus an outgoing repository dispatch completes quickly, but bounding the runner prevents stalled external calls from wasting minutes indefinitely. |
| lint.yml | phpcs | `30` | Composer install plus PHPCS on diffs fits comfortably under half an hour; the cap catches hung runners or stalled caches. |
| codecoverage-main.yml | get-repo-name | `10` | only shells out once to derive the repository basename, so ten minutes provides generous slack without inviting runaway loops. |
| codecoverage-main.yml | codecoverage | `60` | the reusable workflow installs dependencies and runs PHPUnit/Codeception matrices across multiple PHP versions, so a one-hour ceiling better matches plausible worst-case runtimes while still guarding against indefinite stuck jobs. |
| brand-plugin-test-playwright.yml | setup | `10` | branch extraction is instantaneous; minimal timeout trims wasted minutes if scheduling ever misbehaves. |
| brand-plugin-test-playwright.yml | bluehost | `60` | WordPress provisioning, browser installs, npm builds, and Playwright suites are slow; sixty minutes accommodates typical plugin+module workloads without letting jobs run forever. |
| brand-plugin-test-playwright.yml | bluehost-dev | `60` | identical automation path as `bluehost` but pinned to `develop`; same runtime expectations and rationale. |
| newfold-prep-release.yml | prep-release | `45` | Composer/npm installs plus release automation can be lengthy, so forty-five minutes avoids premature cancellations while bounding resource usage. |


## Notes / blockers

| # | Note |
|---:|---|
| 1 | `pull-requests: read` on `lint.yml :: phpcs` is predicated on `technote-space/get-diff-action` calling the GitHub API with `${{ github.token }}`; if future versions switch to purely local git diffs without API calls on some events, that scope might be tightened after verification -- [2] |
| 2 | Caller-side permissions for workflows under `uses: newfold-labs/workflows/... @main` were inferred by reading those reusable workflow sources at `main`; if upstream jobs change materially, rerun the privilege review rather than trusting these caps indefinitely -- [2] |
| 3 | Repository dispatch keeps using `secrets.WEBHOOK_TOKEN`, so widening `GITHUB_TOKEN` scopes remains unnecessary for that step despite the audited job still needing repository read permission for checkout -- [3] |


