### PR TITLE
Enable scheduled Dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,34 @@
+name: Dependabot Auto-Merge
+on:
+  schedule:
+    # Two sweeps a day so a freshly-green (or freshly-rebased) Dependabot PR is
+    # merged within hours instead of waiting a full day. The sweep is cheap.
+    - cron: "0 6 * * *"
+    - cron: "0 18 * * *"
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: Log what would be merged without merging.
+        type: boolean
+        default: false
+
+# Disable permissions for all scopes by default; grant only what the job needs.
+permissions: {}
+
+jobs:
+  # Delegates to the central reusable sweep in newfold-labs/workflows. It finds
+  # every open Dependabot PR and merges the eligible ones (not draft, mergeable,
+  # all check runs green, an opted-in bump type). Majors are left for a human.
+  auto-merge:
+    name: Auto-merge Dependabot PRs
+    uses: newfold-labs/workflows/.github/workflows/reusable-dependabot-auto-merge.yml@main
+    with:
+      merge-method: squash
+      update-types: patch,minor
+      dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || false }}
+    # checks: read lets the reusable read check-run status via the Checks API.
+    # GITHUB_TOKEN reaches the called workflow automatically — no secrets: inherit.
+    permissions:
+      contents: write
+      pull-requests: write
+      checks: read


### PR DESCRIPTION
Adds a scheduled workflow that delegates to the central reusable sweep in `newfold-labs/workflows`. Twice a day it finds every open Dependabot PR and merges the eligible ones — not draft, mergeable, all checks green, and an opted-in bump type (`patch`, `minor`). Majors are left for a human to review.

The workflow file lives on the default branch (`main`) because scheduled workflows only fire from there; the sweep discovers PRs regardless of the branch Dependabot targets, so it merges each into its own base.

Updates stay ungrouped, so each bump is its own PR — a failing bump is isolated to a single named-dependency PR instead of blocking a batch, and auto-merge keeps the open-PR volume low by landing the green ones on its own.

`workflow_dispatch` with `dry-run: true` can be used to preview a sweep first.
